### PR TITLE
Release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to The Sims 4 Updater will be documented in this file.
 
+## [2.9.0] - 2026-02-27
+
+### Fixed
+
+- **Shutdown hang: `_on_close()` doesn't cancel downloads** — window close now sets `updater._cancel` to unblock background download threads before destroying
+- **Indefinite hang: `_proceed.wait()` without timeout** — download pause/resume in both `patch/downloader.py` and `dlc/downloader.py` now loops with 5s timeout + cancel check
+- **Indefinite hang: `_ask_question` event.wait()** — added 120s timeout to prevent permanent hang if GUI thread dies while background thread waits for user answer
+- **Non-atomic GreenLuma install manifest** — `_save_install_manifest()` now writes via temp file + `os.replace()` with cleanup on failure
+- **Non-atomic AppList writes** — `write_applist()` now writes each numbered `.txt` file atomically via temp + `os.replace()`
+- **Non-atomic anadius_override.cfg writes** — all 3 write paths in `_ensure_language_override()` now use `_atomic_write_cfg()` helper
+- **Learned hash DB corruption swallowed silently** — corrupt JSON now logged as warning, backed up to `.json.corrupt`, and starts fresh instead of silently ignoring
+- **DLC uninstall: silent exception swallowing** — `except Exception: pass` in crack config disable replaced with logged warning; non-atomic `shutil.copy2` for Bin_LE replaced with `_atomic_write()`
+- **Cache encoding: system-default file encoding** — `cache.py` `load()`/`save()` now explicitly use `encoding="utf-8"`
+- **Telemetry HTTPS enforcement** — `set_base_url()` rejects non-HTTPS URLs
+- **CDN auth token key validation** — `_refresh()` validates `token` field exists and is a non-empty string before accepting
+- **Telemetry unbounded threads** — replaced per-call `Thread` spawning with bounded `ThreadPoolExecutor(max_workers=2)`
+- **5 frames missing on_show busy guards** — `greenluma_frame`, `language_frame`, `unlocker_frame`, `events_frame`, `mods_frame` now skip `on_show()` refresh if already busy
+- **Unused import** — removed `shutil` from `dlc/manager.py`
+
 ## [2.8.0] - 2026-02-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to The Sims 4 Updater will be documented in this file.
 
+## [2.10.0] - 2026-02-27
+
+### Added
+
+- **Per-DLC download telemetry** — `dlc_item_started` event emitted when each individual DLC begins downloading (includes `dlc_id`, `pack_type`, `size_bytes`)
+- **Download retry/resume tracking** — `DLCDownloadTask` now exposes `retry_count` and `resumed` fields; `dlc_download_complete` event includes `resumed`, `retries`, `registered`, and `pack_type` metadata
+- **DLC batch enrichment** — `dlc_download_started` includes full `dlc_ids` list and `speed_limit_mb`; `dlc_batch_complete` includes `total_retries` and `dlc_ids`
+- **DLC download failure details** — `dlc_download_failed` event now includes `pack_type` and `retries` metadata
+- **Pause duration tracking** — `dlc_download_paused` includes `elapsed_seconds`; `dlc_download_resumed` includes `pause_duration_seconds`
+- **Cancel context** — `dlc_download_cancelled` event includes `completed_before_cancel` and `total_requested`
+- **Patch download phase tracking** — new `patch_download_complete` event with `from_version`, `to_version`, `total_size_bytes`, `duration_seconds`, `avg_speed_bps`; separates download time from apply time
+- **Patch apply phase tracking** — new `patch_apply_complete` event with `to_version`, `duration_seconds`, `dlc_count`
+- **Update completed enrichment** — `update_completed` event now includes `from_version`, `steps`, `total_size_bytes`
+- **DLC toggle detail tracking** — `dlc_changes_applied` event now includes `enabled_ids`, `disabled_ids`, `enabled_count`, `disabled_count` (replacing generic `dlcs_changed` count)
+- **Supabase analytics views** — new `dlc_downloads_by_pack_type`, `patch_download_stats`, `patch_apply_stats`, `dlc_toggle_stats` views; `get_stats()` RPC updated with `dlc_by_pack_type`, `patch_download_stats`, `patch_apply_stats`, `dlc_toggle_stats`, `download_reliability` sections
+- **Performance indexes** — new partial indexes on `events` table for `pack_type` and `patch_download_complete` queries
+
 ## [2.9.0] - 2026-02-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to The Sims 4 Updater will be documented in this file.
 
+## [2.8.0] - 2026-02-27
+
+### Fixed
+
+- **Security: Path traversal in GreenLuma uninstall** — validate file paths stay within install directory using `resolve()` + `is_relative_to()`
+- **Thread safety: ModManager registry mutations** — added `_registry_lock` to prevent concurrent dict modifications from background threads
+- **CDN auth: silent token failure** — `get_token()` now raises `RuntimeError` on refresh failure instead of silently returning empty string; `CDNTokenAuth` adapter catches and skips gracefully
+- **Downloader: double-checked locking race** — session now fully configured before publishing to shared `_session` attribute
+- **LearnedHashDB thread safety** — all mutations (`save`, `add_version`, `merge`) now protected by `threading.Lock`
+- **GUI blocking: GreenLuma subprocess on main thread** — `is_steam_running()` calls in `greenluma_frame.py` moved to background thread via `run_async()`
+- **Diagnostics: validator constructor outside try block** — `GameValidator()` now inside the exception handler so failures don't silently leave `_validator_running` stuck
+- **Version detection: false DEFINITIVE confidence** — single-sentinel matches no longer report `DEFINITIVE`; requires at least 2 matching sentinels
+- **DLC config: non-atomic Bin_LE write** — replaced `shutil.copy2` with `_atomic_write()` for crash safety
+- **Language frame: async race condition** — removed duplicate `_refresh_status()` call that raced with `_apply_language()`
+- **Steam detection: missing HKCU registry lookup** — `_read_steam_path_from_registry()` now checks both `HKEY_LOCAL_MACHINE` and `HKEY_CURRENT_USER`
+- **Language changer: registry key creation** — use `CreateKeyEx` instead of `OpenKey` so the key is created if it doesn't exist
+- **Language changer: non-atomic appmanifest write** — Steam manifest updates now use temp file + `os.replace()`
+- **DepotDownloader: HTTPS validation** — reject download URLs that don't use HTTPS
+- **Contribution URLs: HTTPS enforcement** — both DLC and GreenLuma contribution endpoints now reject non-HTTPS URLs
+
 ## [2.7.1] - 2026-02-27
 
 ### Fixed

--- a/Documentation/Architecture_and_Developer_Guide.md
+++ b/Documentation/Architecture_and_Developer_Guide.md
@@ -1,6 +1,6 @@
 # Sims 4 Updater — Architecture and Developer Guide
 
-**Version:** 2.3.0
+**Version:** 2.10.0
 **Author:** ToastyToast25
 **Last Updated:** February 2026
 
@@ -1347,6 +1347,69 @@ Manages JWT session token lifecycle for CDN access.
 - `CDNTokenAuth(AuthBase)` — requests auth adapter. Set as `session.auth`; runs on every HTTP request, calling `get_token()` each time. Handles multi-hour batch downloads seamlessly.
 
 **Integration:** After manifest fetch, `App` creates `CDNAuth`, sets `session.auth = cdn_auth.get_auth_adapter()`.
+
+### 5.26 Core: Telemetry
+
+**File:** `src/sims4_updater/core/telemetry.py`
+
+Anonymous telemetry via Cloudflare Worker → Supabase. All methods are fire-and-forget: they catch all exceptions internally and never raise. Respects the `telemetry_enabled` user setting.
+
+**TelemetryClient class:**
+
+```python
+class TelemetryClient:
+    def __init__(self, settings: Settings, base_url: str = "") -> None
+    def heartbeat(*, game_version, crack_format, dlc_count, game_detected, locale) -> None
+    def track_event(event_type: str, metadata: dict | None = None) -> None
+    def set_game_info(*, game_version, crack_format, dlc_count, game_detected, locale) -> None
+    def set_base_url(url: str) -> None
+    def start_periodic_heartbeat(interval: int = 300) -> None
+    def stop_periodic_heartbeat() -> None
+    def session_end() -> None
+```
+
+**Key design decisions:**
+
+- Uses a `ThreadPoolExecutor(max_workers=2)` for non-blocking POSTs — never blocks the GUI
+- UID generated once per user (`uuid4().hex`), saved to `settings.json`
+- Session ID generated per app launch (`uuid4().hex`)
+- Auto-disables on 403 response (banned) to avoid spamming a rejecting endpoint
+- Periodic heartbeat runs on a daemon thread, defaults to every 5 minutes
+- Identity headers (`X-Machine-Id`, `X-UID`) injected via `core/identity.py`
+- `session_end()` fires a `session_end` event with `duration_seconds` and stops the periodic heartbeat
+
+**Tracked event types:**
+
+| Event | Source | Metadata |
+| --- | --- | --- |
+| `frame_navigation` | `app.py` | `from_frame`, `to_frame` |
+| `update_started` | `progress_frame.py` | `from_version`, `to_version`, `steps`, `total_size_bytes` |
+| `update_completed` | `progress_frame.py` | `from_version`, `to_version`, `steps`, `total_size_bytes`, `duration_seconds` |
+| `update_failed` | `progress_frame.py` | `error` (truncated to 200 chars) |
+| `update_cancelled` | `progress_frame.py` | — |
+| `patch_download_complete` | `progress_frame.py` | `from_version`, `to_version`, `steps`, `total_size_bytes`, `duration_seconds`, `avg_speed_bps` |
+| `patch_apply_complete` | `progress_frame.py` | `to_version`, `duration_seconds`, `dlc_count` |
+| `dlc_download_started` | `downloader_frame.py` | `dlc_count`, `dlc_ids`, `total_size_bytes`, `concurrency`, `speed_limit_mb` |
+| `dlc_item_started` | `downloader_frame.py` | `dlc_id`, `pack_type`, `size_bytes` |
+| `dlc_download_complete` | `downloader_frame.py` | `dlc_id`, `pack_type`, `size_bytes`, `duration_seconds`, `speed_bps`, `resumed`, `retries`, `registered` |
+| `dlc_download_failed` | `downloader_frame.py` | `dlc_id`, `pack_type`, `retries`, `error` |
+| `dlc_batch_complete` | `downloader_frame.py` | `total`, `completed`, `failed`, `cancelled`, `duration_seconds`, `total_bytes`, `total_retries`, `dlc_ids` |
+| `dlc_download_paused` | `downloader_frame.py` | `elapsed_seconds` |
+| `dlc_download_resumed` | `downloader_frame.py` | `pause_duration_seconds` |
+| `dlc_download_cancelled` | `downloader_frame.py` | `completed_before_cancel`, `total_requested` |
+| `dlc_changes_applied` | `dlc_frame.py` | `enabled_count`, `disabled_count`, `enabled_ids`, `disabled_ids`, `crack_format` |
+| `session_end` | `telemetry.py` | `session_id`, `duration_seconds` |
+| `self_update_started` | `home_frame.py` | `from_version`, `to_version` |
+| `self_update_completed` | `home_frame.py` | `to_version` |
+| `self_update_failed` | `home_frame.py` | `error` |
+
+**Usage from GUI frames:**
+
+```python
+self.app.telemetry.track_event("event_type", {"key": "value"})
+```
+
+All telemetry calls go through the `App.telemetry` attribute, which is initialized in `App.__init__()`. The `TelemetryClient` is configured with the telemetry URL from the manifest (`cdn.telemetry_url`) after the first manifest fetch.
 
 ---
 

--- a/Documentation/CDN_Infrastructure.md
+++ b/Documentation/CDN_Infrastructure.md
@@ -2,8 +2,8 @@
 
 **Project**: The Sims 4 Updater
 **CDN Domain**: cdn.example.com
-**Last Updated**: 2026-02-22
-**Applies to:** Sims 4 Updater v2.3.0
+**Last Updated**: 2026-02-27
+**Applies to:** Sims 4 Updater v2.10.0
 
 ---
 
@@ -901,7 +901,7 @@ Four password-protected dashboards (`?pw=ADMIN_PASSWORD`):
 
 | Dashboard | Route | Features |
 | --- | --- | --- |
-| Analytics | `/admin/stats` | Online users, version stats, crack formats, DLC popularity, download volume |
+| Analytics | `/admin/stats` | Online users, DAU/WAU/MAU, version/crack/locale distribution, events, popular DLCs, download volume, download reliability, patch performance, DLC by pack type, DLC toggles, daily trends |
 | Contributions | `/admin` | DLC + GreenLuma contribution review and approval |
 | Bans | `/admin/bans` | Create/remove bans, connected clients table, CDN access mode toggle, ban from client list |
 | Access | `/admin/access` | Access request review with status filters, search, bulk approve/deny with checkboxes |
@@ -915,6 +915,36 @@ Every token request is logged to the `token_log` table with an upsert trigger:
 - Tracks: machine_id, uid, ip, app_version, request_count, first_seen, last_seen
 - Visible in the Bans dashboard "Connected Clients" section
 - Admins can ban directly from the client list
+
+### Analytics Dashboard Details
+
+The analytics dashboard (`/admin/stats`) fetches all data via the `get_stats(p_days)` Supabase RPC function, which returns 20+ analytics sections in a single call. The dashboard includes a time range selector (7d / 30d / 90d / All time) that re-fetches stats for the chosen window.
+
+**Dashboard sections:**
+
+| Section | Visualization | Data Source |
+| --- | --- | --- |
+| Online Users | Metric card | Users with `last_seen` in last 6 minutes |
+| Active Users | DAU/WAU/MAU/Total metrics | `users` table with time filters |
+| App Version Distribution | Bar chart | `users.app_version` grouped |
+| Game Version Distribution | Bar chart | `users.game_version` grouped |
+| Crack Format Distribution | Bar chart | `users.crack_format` grouped |
+| Locale Distribution | Bar chart | `users.locale` grouped |
+| Event Types | Bar chart | `events.event_type` grouped |
+| Popular DLCs | Bar chart (top 20) | `dlc_download_complete` events |
+| Download Volume | Metrics (count, bytes, speed) | `dlc_download_complete` events |
+| Download Reliability | Metrics (first-try %, retries, resumes, reg failures) | `dlc_download_complete` events |
+| Patch Performance | Metrics (download/apply count, speed, duration) | `patch_download_complete` + `patch_apply_complete` events |
+| DLC by Pack Type | Bar chart | `dlc_download_complete` grouped by `pack_type` |
+| DLC Toggles | Metrics (applies, enabled, disabled) | `dlc_changes_applied` events |
+| Update Stats | Started/completed/failed metrics | `update_*` events |
+| Session Stats | Count, avg/max duration | `session_end` events |
+| Feature Usage | Table (frame visits) | `frame_navigation` events |
+| Error Summary | Table (type, count, affected users) | Error events |
+| DLC Count Distribution | Table (buckets) | `users.dlc_count` bucketed |
+| Daily Active Trend | Sparkline chart | Daily distinct UIDs (up to 90 days) |
+| New Users Daily | Sparkline chart | `users.created_at` by day |
+| Daily Events Trend | Sparkline chart | Event count by day |
 
 ### Supabase Schema
 
@@ -957,10 +987,19 @@ Every token request is logged to the `token_log` table with an upsert trigger:
 | POST | `/auth/token` | Request JWT session token |
 | POST | `/access/request` | Submit access request (private CDNs) |
 
+**Telemetry (from client app):**
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| POST | `/stats/heartbeat` | Upsert user record with system info |
+| POST | `/stats/event` | Append telemetry event to events log |
+
 **Admin (password-protected):**
 
 | Method | Path | Purpose |
 | --- | --- | --- |
+| GET | `/admin/stats` | Analytics dashboard (calls `get_stats()` RPC) |
+| GET | `/admin` | Contribution review dashboard |
 | GET | `/admin/bans` | Ban management dashboard |
 | GET | `/admin/bans/api` | List all bans + summary |
 | POST | `/admin/bans/create` | Create a ban |

--- a/Documentation/DLC_Management_System.md
+++ b/Documentation/DLC_Management_System.md
@@ -1,8 +1,8 @@
 # DLC Management System — Technical Reference
 
 **Project:** Sims 4 Updater
-**Document Version:** 2.3.0
-**Date:** 2026-02-20
+**Document Version:** 2.10.0
+**Date:** 2026-02-27
 **Scope:** The complete DLC management subsystem, covering catalog data, state detection, crack config formats, download pipeline, unlocker integration, and GUI.
 
 ---
@@ -855,9 +855,11 @@ class DLCDownloadTask:
     progress_bytes: int = 0   # Bytes downloaded so far
     total_bytes: int = 0      # Total expected bytes (from manifest)
     error: str = ""           # Error message if state == FAILED
+    retry_count: int = 0      # Number of retries before success (0 = first try)
+    resumed: bool = False     # Whether HTTP resume was used
 ```
 
-One `DLCDownloadTask` is created per DLC download. It is updated in-place as the pipeline advances through phases.
+One `DLCDownloadTask` is created per DLC download. It is updated in-place as the pipeline advances through phases. The `retry_count` and `resumed` fields are set after a successful download and are used by the GUI for telemetry reporting (see Section 7.12).
 
 ### 7.3 DLCStatusCallback Type
 
@@ -1049,6 +1051,33 @@ If `_register_dlc()` raises an exception (e.g., no crack config found), the task
 ```
 
 This design decision treats file extraction as the primary success criterion. The DLC files are on disk and can be manually registered later via the "Apply Changes" button in the GUI. A missing crack config at this point is a configuration issue, not a download failure.
+
+### 7.12 Telemetry Events
+
+The DLC download pipeline and DLC toggle operations emit telemetry events for server-side analytics. All events are fired from the GUI layer (`downloader_frame.py` and `dlc_frame.py`) via `app.telemetry.track_event()`.
+
+**Download events:**
+
+| Event | When | Key Metadata |
+| --- | --- | --- |
+| `dlc_download_started` | Batch download begins | `dlc_count`, `dlc_ids`, `total_size_bytes`, `concurrency`, `speed_limit_mb` |
+| `dlc_item_started` | Individual DLC begins downloading | `dlc_id`, `pack_type`, `size_bytes` |
+| `dlc_download_complete` | Individual DLC finishes successfully | `dlc_id`, `pack_type`, `size_bytes`, `duration_seconds`, `speed_bps`, `resumed`, `retries`, `registered` |
+| `dlc_download_failed` | Individual DLC fails | `dlc_id`, `pack_type`, `retries`, `error` |
+| `dlc_batch_complete` | All DLCs in batch finished | `total`, `completed`, `failed`, `cancelled`, `duration_seconds`, `total_bytes`, `total_retries`, `dlc_ids` |
+| `dlc_download_paused` | User pauses downloads | `elapsed_seconds` |
+| `dlc_download_resumed` | User resumes downloads | `pause_duration_seconds` |
+| `dlc_download_cancelled` | User cancels downloads | `completed_before_cancel`, `total_requested` |
+
+The `resumed` and `retries` fields in per-DLC events come from the `DLCDownloadTask` dataclass, which is populated by the download retry loop. The `registered` field indicates whether Phase 3 (crack config registration) succeeded.
+
+**DLC toggle events:**
+
+| Event | When | Key Metadata |
+| --- | --- | --- |
+| `dlc_changes_applied` | User applies DLC config changes | `enabled_count`, `disabled_count`, `enabled_ids`, `disabled_ids`, `crack_format` |
+
+The toggle event captures the diff between the pre-apply and post-apply enabled sets, reporting which specific DLCs were enabled or disabled (capped at 20 IDs each to avoid oversized payloads).
 
 ---
 

--- a/Documentation/Supabase_Setup_Guide.md
+++ b/Documentation/Supabase_Setup_Guide.md
@@ -1,7 +1,7 @@
 # Supabase Setup Guide
 
 **Project**: The Sims 4 Updater
-**Last Updated**: 2026-02-23
+**Last Updated**: 2026-02-27
 
 ---
 
@@ -83,7 +83,7 @@ You should see `Success. No rows returned` — this means all tables, views, ind
 | `cdn_settings` | Dynamic key-value configuration |
 | `token_log` | Connected client tracking (one row per machine) |
 
-**Views (10)**: `online_users`, `active_users`, `version_stats`, `crack_format_stats`, `locale_stats`, `event_stats`, `popular_dlcs`, `update_stats`, `download_volume`, `session_stats`, `active_bans`, `bans_summary`
+**Views (16)**: `online_users`, `active_users`, `version_stats`, `crack_format_stats`, `locale_stats`, `event_stats`, `popular_dlcs`, `update_stats`, `download_volume`, `session_stats`, `active_bans`, `bans_summary`, `dlc_downloads_by_pack_type`, `patch_download_stats`, `patch_apply_stats`, `dlc_toggle_stats`
 
 **Triggers (1)**: `token_log_upsert_trigger` — auto-updates `last_seen` and increments `request_count` when a client reconnects
 
@@ -378,6 +378,10 @@ Default settings:
 | `update_stats` | Update started/completed/failed (30 days) | Analytics dashboard |
 | `download_volume` | Total downloads, bytes, speed (30 days) | Analytics dashboard |
 | `session_stats` | Session count and duration (30 days) | Analytics dashboard |
+| `dlc_downloads_by_pack_type` | DLC downloads grouped by pack type with speed/retry stats (30 days) | Analytics dashboard |
+| `patch_download_stats` | Patch download performance — count, bytes, duration, speed (30 days) | Analytics dashboard |
+| `patch_apply_stats` | Patch apply performance — count and average duration (30 days) | Analytics dashboard |
+| `dlc_toggle_stats` | DLC config changes — enable/disable counts (30 days) | Analytics dashboard |
 | `active_bans` | Currently enforced bans (excludes expired) | CDN/API Workers |
 | `bans_summary` | Ban count breakdown by status | Bans dashboard |
 
@@ -395,12 +399,60 @@ Four admin dashboards are served by the API Worker, all password-protected:
 
 | Dashboard | URL | Features |
 |-----------|-----|----------|
-| **Analytics** | `/admin/analytics?pw=...` | Online users, DAU/WAU/MAU, version/crack/locale charts, events, popular DLCs, download volume |
+| **Analytics** | `/admin/analytics?pw=...` | Online users, DAU/WAU/MAU, version/crack/locale charts, events, popular DLCs, download volume, download reliability, patch performance, DLC downloads by pack type, DLC toggles |
 | **Contributions** | `/admin/contributions?pw=...` | User-submitted DLC metadata and depot keys |
 | **Bans** | `/admin/bans?pw=...` | Create/remove bans, connected clients list, CDN access mode toggle |
 | **Access** | `/admin/access?pw=...` | Review/approve/deny access requests, bulk actions (private CDN only) |
 
 All dashboards auto-refresh every 30 seconds.
+
+### `get_stats()` RPC Function
+
+The analytics dashboard uses a single PostgreSQL function `get_stats(p_days)` to fetch all stats in one call. It accepts a time window in days (default 30, pass 0 for all-time) and returns a JSONB object with the following sections:
+
+| Section | Description |
+|---------|-------------|
+| `online_users` | Count of users seen in last 6 minutes (always real-time, ignores time range) |
+| `active_users` | DAU, WAU, MAU, and total user counts |
+| `version_stats` | App version distribution |
+| `game_version_stats` | Game version distribution |
+| `crack_format_stats` | Crack format distribution |
+| `locale_stats` | Locale/language distribution |
+| `event_stats` | Event type totals |
+| `popular_dlcs` | Top 20 downloaded DLCs by count |
+| `update_stats` | Update started/completed/failed counts |
+| `download_volume` | Total DLC downloads, bytes, avg speed |
+| `session_stats` | Session count and duration |
+| `feature_usage` | Frame navigation counts (UI feature usage) |
+| `error_summary` | Error events with affected user counts |
+| `dlc_count_distribution` | Users bucketed by installed DLC count |
+| `daily_active_trend` | Daily active users time series (up to 90 days) |
+| `new_users_daily` | New user registrations per day |
+| `daily_events_trend` | Total events per day time series |
+| `dlc_by_pack_type` | DLC downloads grouped by pack type (expansion/game_pack/stuff_pack/kit) with resume, retry, and speed stats |
+| `patch_download_stats` | Patch download performance — count, total bytes, avg duration, avg speed |
+| `patch_apply_stats` | Patch apply performance — count, avg apply duration |
+| `dlc_toggle_stats` | DLC config changes — total applies, enabled count, disabled count |
+| `download_reliability` | Download retry rate, resume rate, and registration failure rate |
+
+### Indexes
+
+Performance indexes for analytics queries:
+
+| Index | Table | Purpose |
+|-------|-------|---------|
+| `idx_events_type_created` | `events` | Event type + created_at for time-range queries |
+| `idx_events_dlc_pack_type` | `events` | Partial index on `metadata->>'pack_type'` for `dlc_download_complete` events |
+| `idx_events_patch_download` | `events` | Partial index on `created_at` for `patch_download_complete` events |
+
+### Running Migrations
+
+After the initial schema (`supabase_setup.sql`), apply migrations in order from `supabase/migrations/`:
+
+1. `20260227_stats_rpc.sql` — Base `get_stats()` RPC function
+2. `20260303_download_telemetry_views.sql` — Enhanced download/DLC tracking views and updated `get_stats()`
+
+Run each migration in the Supabase SQL Editor in chronological order.
 
 ---
 

--- a/Documentation/Update_and_Patching_System.md
+++ b/Documentation/Update_and_Patching_System.md
@@ -1,8 +1,8 @@
 # Update and Patching System — Technical Reference
 
 **Project:** Sims 4 Updater
-**Version Documented:** 2.3.0
-**Date:** 2026-02-20
+**Version Documented:** 2.10.0
+**Date:** 2026-02-27
 **Scope:** Core update pipeline, version detection, manifest parsing, update planning, download management, patch application, DLC state preservation, and hash learning
 
 ---
@@ -2129,6 +2129,23 @@ def get_tools_dir():
 ```
 
 When frozen by PyInstaller, `sys._MEIPASS` points to the temporary directory where the bundled data files are extracted. The `data/` directory contains `version_hashes.json` and the `tools/` directory contains `xdelta3.exe` and `unrar.exe`.
+
+---
+
+## 13. Telemetry Events
+
+The update pipeline emits telemetry events for server-side analytics. All events are fired from `progress_frame.py` via `app.telemetry.track_event()`.
+
+| Event | When | Key Metadata |
+| --- | --- | --- |
+| `update_started` | User clicks "Update Now" | `from_version`, `to_version`, `steps`, `total_size_bytes` |
+| `patch_download_complete` | All patch archives downloaded | `from_version`, `to_version`, `steps`, `total_size_bytes`, `duration_seconds`, `avg_speed_bps` |
+| `patch_apply_complete` | All patches applied to game files | `to_version`, `duration_seconds`, `dlc_count` |
+| `update_completed` | Full pipeline finished successfully | `from_version`, `to_version`, `steps`, `total_size_bytes`, `duration_seconds` |
+| `update_failed` | Pipeline failed at any point | `error` (truncated to 200 chars) |
+| `update_cancelled` | User cancelled the update | — |
+
+The `patch_download_complete` and `patch_apply_complete` events provide phase-level timing, enabling server-side analysis of where time is spent during updates (network download vs. disk I/O). The `avg_speed_bps` field reports the average download throughput in bytes per second.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,13 +132,17 @@ Real-time play time display on the homepage when the game is running. Shows elap
 
 Every major operation is available headlessly for scripting and automation.
 
+### Telemetry & Analytics
+
+Anonymous, opt-in telemetry tracks usage patterns and download performance for CDN operators. Events include per-DLC download metrics (speed, retries, resume, registration success), patch download and apply phase timing, DLC toggle diffs, frame navigation, and session duration. All data flows through the Cloudflare API Worker to Supabase. Users can disable telemetry in the Settings tab.
+
 ### Admin Dashboards
 
 Four password-protected admin dashboards for CDN management:
 
 | Dashboard | URL | Purpose |
 | --- | --- | --- |
-| **Analytics** | `/admin/stats` | Real-time telemetry: online users, version distribution, crack formats, DLC popularity, download volume |
+| **Analytics** | `/admin/stats` | Real-time telemetry: online users, DAU/WAU/MAU, version/crack/locale distribution, DLC popularity, download volume, download reliability (retry/resume rates), patch performance (download + apply timing), DLC downloads by pack type, DLC toggles, daily active trends, error summary |
 | **Contributions** | `/admin` | Review and approve DLC and GreenLuma key contributions |
 | **Bans** | `/admin/bans` | Create/remove bans, view connected clients, toggle CDN public/private mode |
 | **Access** | `/admin/access` | Review access requests for private CDNs with bulk approve/deny |
@@ -549,7 +553,7 @@ pytest tests/ -v --tb=short
 sims4-updater/
 ├── src/
 │   ├── sims4_updater/
-│   │   ├── __init__.py              # VERSION string ("2.5.0")
+│   │   ├── __init__.py              # VERSION string ("2.10.0")
 │   │   ├── __main__.py              # CLI argparse entry point + GUI launcher
 │   │   ├── constants.py             # SENTINEL_FILES, registry paths, get_data_dir(), get_tools_dir()
 │   │   ├── config.py                # Settings dataclass, get_app_dir() -> %LOCALAPPDATA%\ToastyToast25\
@@ -573,6 +577,7 @@ sims4-updater/
 │   │   │   ├── machine_id.py        # Machine fingerprint (SHA256 of Windows MachineGuid)
 │   │   │   ├── identity.py          # Shared identity headers for CDN requests
 │   │   │   ├── cdn_auth.py          # JWT session token lifecycle
+│   │   │   ├── telemetry.py         # Anonymous telemetry (heartbeat, events) via Cloudflare Worker → Supabase
 │   │   │   └── utils.py             # Size parsing utilities
 │   │   ├── patch/
 │   │   │   ├── manifest.py          # Manifest, PatchEntry, FileEntry, DLCDownloadEntry, GreenLumaEntry, parse_manifest()
@@ -691,6 +696,7 @@ Full technical reference for all subsystems:
 | [DLC Packer and Distribution](Documentation/DLC_Packer_and_Distribution.md) | Packer class internals, ZIP format specification, manifest generation, import flow, distribution workflow |
 | [GreenLuma Integration](Documentation/GreenLuma_Integration.md) | Steam detection, AppList management, config.vdf depot keys, LUA manifest parsing, depotcache, orchestrator |
 | [CDN Infrastructure](Documentation/CDN_Infrastructure.md) | Cloudflare Worker proxy, KV routing, seedbox integration, JWT auth, ban system, admin dashboards |
+| [Supabase Setup Guide](Documentation/Supabase_Setup_Guide.md) | Database schema, views, RPC functions, admin dashboard setup, worker secrets, maintenance |
 
 ---
 

--- a/cloudflare-worker/api-worker.js
+++ b/cloudflare-worker/api-worker.js
@@ -1324,6 +1324,59 @@ function render(stats, events) {
   h += '<div class="metric"><div class="metric-value orange">' + fmtDuration(dv.avg_duration || 0) + '</div><div class="metric-label">Avg DL Duration</div></div>';
   h += '</div>';
 
+  // Download reliability
+  var dr = row(stats.download_reliability || []);
+  if (dr.total_downloads > 0) {
+    h += '<div class="section-title">Download Reliability (' + getRangeLabel() + ')</div>';
+    h += '<div class="metrics" style="grid-template-columns:repeat(4,1fr)">';
+    h += '<div class="metric"><div class="metric-value green">' + fmtPct(dr.total_downloads - (dr.with_retries || 0), dr.total_downloads) + '</div><div class="metric-label">First-Try Success</div></div>';
+    h += '<div class="metric"><div class="metric-value orange">' + (dr.with_retries || 0) + '</div><div class="metric-label">Needed Retries</div></div>';
+    h += '<div class="metric"><div class="metric-value blue">' + (dr.with_resume || 0) + '</div><div class="metric-label">Resumed Downloads</div></div>';
+    h += '<div class="metric"><div class="metric-value red">' + (dr.registration_failures || 0) + '</div><div class="metric-label">Registration Failures</div></div>';
+    h += '</div>';
+  }
+
+  // Patch performance
+  var pds = row(stats.patch_download_stats || []);
+  var pas = row(stats.patch_apply_stats || []);
+  if ((pds.total_downloads || 0) > 0 || (pas.total_applies || 0) > 0) {
+    h += '<div class="section-title">Patch Performance (' + getRangeLabel() + ')</div>';
+    h += '<div class="metrics" style="grid-template-columns:repeat(5,1fr)">';
+    h += '<div class="metric"><div class="metric-value blue">' + (pds.total_downloads || 0) + '</div><div class="metric-label">Patch Downloads</div></div>';
+    h += '<div class="metric"><div class="metric-value blue">' + fmtSize(pds.total_bytes || 0) + '</div><div class="metric-label">Patch Volume</div></div>';
+    h += '<div class="metric"><div class="metric-value orange">' + fmtSpeed(pds.avg_speed_bps || 0) + '</div><div class="metric-label">Avg Patch DL Speed</div></div>';
+    h += '<div class="metric"><div class="metric-value orange">' + fmtDuration(pds.avg_download_seconds || 0) + '</div><div class="metric-label">Avg DL Time</div></div>';
+    h += '<div class="metric"><div class="metric-value green">' + fmtDuration(pas.avg_apply_seconds || 0) + '</div><div class="metric-label">Avg Apply Time</div></div>';
+    h += '</div>';
+  }
+
+  // DLC by pack type
+  var dpt = (stats.dlc_by_pack_type || []).map(function(r) {
+    return {label: r.pack_type || "?", count: r.downloads, extra: fmtSize(r.total_bytes || 0)};
+  });
+  if (dpt.length > 0) {
+    h += '<div class="section-title">DLC Downloads by Pack Type (' + getRangeLabel() + ')</div>';
+    h += '<div class="charts">';
+    var maxPt = Math.max.apply(null, dpt.map(function(i) { return i.count; }));
+    h += '<div class="chart-card"><div class="chart-title">Pack Type</div>';
+    dpt.forEach(function(item) {
+      var pct = maxPt > 0 ? Math.max(2, (item.count / maxPt) * 100) : 2;
+      h += '<div class="bar-row"><span class="bar-label">' + esc(item.label) + '</span>';
+      h += '<div class="bar-track"><div class="bar-fill green" style="width:' + pct + '%"></div></div>';
+      h += '<span class="bar-count">' + item.count + ' (' + item.extra + ')</span></div>';
+    });
+    h += '</div>';
+    // DLC toggle stats
+    var dts = row(stats.dlc_toggle_stats || []);
+    h += '<div class="chart-card"><div class="chart-title">DLC Toggles</div>';
+    h += '<div style="padding:16px;font-size:14px;color:#8b949e">';
+    h += '<div style="margin-bottom:8px">\u{1F504} <strong>' + (dts.total_applies || 0) + '</strong> config applies</div>';
+    h += '<div style="margin-bottom:8px">\u2705 <strong>' + (dts.total_enabled || 0) + '</strong> DLCs enabled</div>';
+    h += '<div>\u274C <strong>' + (dts.total_disabled || 0) + '</strong> DLCs disabled</div>';
+    h += '</div></div>';
+    h += '</div>';
+  }
+
   // Event type breakdown
   var es = (stats.event_stats || []).map(function(r) { return {label: r.event_type, count: r.count}; });
   h += '<div class="section-title">Event Types (' + getRangeLabel() + ')</div>';

--- a/src/sims4_updater/__init__.py
+++ b/src/sims4_updater/__init__.py
@@ -1,4 +1,4 @@
-VERSION = "2.7.1"
+VERSION = "2.8.0"
 
 # Ensure the sibling patcher package is importable (dev & PyInstaller)
 import sys as _sys  # noqa: E402

--- a/src/sims4_updater/__init__.py
+++ b/src/sims4_updater/__init__.py
@@ -1,4 +1,4 @@
-VERSION = "2.8.0"
+VERSION = "2.9.0"
 
 # Ensure the sibling patcher package is importable (dev & PyInstaller)
 import sys as _sys  # noqa: E402

--- a/src/sims4_updater/__init__.py
+++ b/src/sims4_updater/__init__.py
@@ -1,4 +1,4 @@
-VERSION = "2.9.0"
+VERSION = "2.10.0"
 
 # Ensure the sibling patcher package is importable (dev & PyInstaller)
 import sys as _sys  # noqa: E402

--- a/src/sims4_updater/core/cache.py
+++ b/src/sims4_updater/core/cache.py
@@ -10,7 +10,7 @@ __all__ = ["load", "save"]
 
 def load(path):
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             return json.load(f)
     except (
         FileNotFoundError,
@@ -33,7 +33,7 @@ def save(path, obj):
     path = str(path)
     path_tmp = f"{path}_tmp"
     try:
-        with open(path_tmp, "w") as f:
+        with open(path_tmp, "w", encoding="utf-8") as f:
             f.write(serialized)
         os.replace(path_tmp, path)
     except (OSError, PermissionError) as e:

--- a/src/sims4_updater/core/cdn_auth.py
+++ b/src/sims4_updater/core/cdn_auth.py
@@ -37,7 +37,10 @@ class CDNTokenAuth(AuthBase):
         self._cdn_auth = cdn_auth
 
     def __call__(self, r: requests.PreparedRequest) -> requests.PreparedRequest:
-        token = self._cdn_auth.get_token()
+        try:
+            token = self._cdn_auth.get_token()
+        except RuntimeError:
+            token = ""
         if token:
             r.headers["Authorization"] = f"Bearer {token}"
         return r
@@ -117,6 +120,8 @@ class CDNAuth:
             if self._token and time.monotonic() < self._expires_at - 60:
                 return self._token
             self._refresh()
+        if not self._token:
+            raise RuntimeError("Token refresh failed — no valid token available.")
         return self._token
 
     def get_auth_adapter(self) -> CDNTokenAuth:

--- a/src/sims4_updater/core/cdn_auth.py
+++ b/src/sims4_updater/core/cdn_auth.py
@@ -235,8 +235,12 @@ class CDNAuth:
 
         try:
             data = resp.json()
+            token = data.get("token", "")
+            if not token or not isinstance(token, str):
+                log.warning("CDN token response missing valid 'token' field")
+                return
             with self._lock:
-                self._token = data["token"]
+                self._token = token
                 self._expires_at = time.monotonic() + data.get("expires_in", 3600)
         except Exception as exc:
             log.warning("CDN token parse error: %s", exc)

--- a/src/sims4_updater/core/contribute.py
+++ b/src/sims4_updater/core/contribute.py
@@ -154,6 +154,8 @@ def submit_contribution(
     endpoint = url or CONTRIBUTE_URL
     if not endpoint:
         return {"status": "error", "message": "Contribution URL not configured."}
+    if not endpoint.startswith("https://"):
+        return {"status": "error", "message": "Contribution URL must use HTTPS."}
 
     from . import identity
 

--- a/src/sims4_updater/core/learned_hashes.py
+++ b/src/sims4_updater/core/learned_hashes.py
@@ -11,12 +11,15 @@ Persisted at %LocalAppData%/ToastyToast25/sims4_updater/learned_hashes.json
 """
 
 import json
+import logging
 import os
 import threading
 import time
 from pathlib import Path
 
 from ..config import get_app_dir
+
+logger = logging.getLogger(__name__)
 
 
 def _default_path() -> Path:
@@ -40,10 +43,21 @@ class LearnedHashDB:
         try:
             with open(self.path, encoding="utf-8") as f:
                 data = json.load(f)
+            if not isinstance(data, dict):
+                raise ValueError("Root must be a JSON object")
             self.sentinel_files = data.get("sentinel_files", [])
             self.versions = data.get("versions", {})
-        except (json.JSONDecodeError, OSError):
-            pass
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warning("Corrupt learned hash DB at %s: %s — starting fresh", self.path, e)
+            # Back up corrupt file so user data isn't lost
+            backup = self.path.with_suffix(".json.corrupt")
+            try:
+                os.replace(self.path, backup)
+                logger.info("Backed up corrupt DB to %s", backup)
+            except OSError:
+                pass
+        except OSError as e:
+            logger.warning("Could not read learned hash DB: %s", e)
 
     def save(self):
         """Write the database to disk (atomic)."""

--- a/src/sims4_updater/core/learned_hashes.py
+++ b/src/sims4_updater/core/learned_hashes.py
@@ -12,6 +12,7 @@ Persisted at %LocalAppData%/ToastyToast25/sims4_updater/learned_hashes.json
 
 import json
 import os
+import threading
 import time
 from pathlib import Path
 
@@ -30,6 +31,7 @@ class LearnedHashDB:
         self.sentinel_files: list[str] = []
         self.versions: dict[str, dict[str, str]] = {}
         self._dirty = False
+        self._lock = threading.Lock()
         self._load()
 
     def _load(self):
@@ -45,14 +47,16 @@ class LearnedHashDB:
 
     def save(self):
         """Write the database to disk (atomic)."""
-        if not self._dirty and self.path.is_file():
-            return
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        data = {
-            "sentinel_files": self.sentinel_files,
-            "versions": self.versions,
-            "updated": int(time.time()),
-        }
+        with self._lock:
+            if not self._dirty and self.path.is_file():
+                return
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            data = {
+                "sentinel_files": list(self.sentinel_files),
+                "versions": {v: dict(h) for v, h in self.versions.items()},
+                "updated": int(time.time()),
+            }
+            self._dirty = False
         tmp = self.path.with_suffix(".json_tmp")
         try:
             with open(tmp, "w", encoding="utf-8") as f:
@@ -61,7 +65,6 @@ class LearnedHashDB:
         except BaseException:
             tmp.unlink(missing_ok=True)
             raise
-        self._dirty = False
 
     def add_version(self, version: str, hashes: dict[str, str]):
         """Add or update a version's fingerprint.
@@ -73,34 +76,35 @@ class LearnedHashDB:
         if not version or not hashes:
             return
 
-        # Update sentinel list if needed
-        for sentinel in hashes:
-            if sentinel not in self.sentinel_files:
-                self.sentinel_files.append(sentinel)
+        with self._lock:
+            for sentinel in hashes:
+                if sentinel not in self.sentinel_files:
+                    self.sentinel_files.append(sentinel)
 
-        existing = self.versions.get(version, {})
-        if existing == hashes:
-            return  # no change
+            existing = self.versions.get(version, {})
+            if existing == hashes:
+                return  # no change
 
-        self.versions[version] = hashes
-        self._dirty = True
+            self.versions[version] = hashes
+            self._dirty = True
 
     def merge(self, other_versions: dict[str, dict[str, str]]):
         """Merge another set of version fingerprints into this DB.
 
         Existing entries are updated (new hashes override old ones per sentinel).
         """
-        for version, hashes in other_versions.items():
-            if not hashes:
-                continue
-            existing = self.versions.get(version, {})
-            merged = {**existing, **hashes}
-            if merged != existing:
-                self.versions[version] = merged
-                self._dirty = True
-                for sentinel in hashes:
-                    if sentinel not in self.sentinel_files:
-                        self.sentinel_files.append(sentinel)
+        with self._lock:
+            for version, hashes in other_versions.items():
+                if not hashes:
+                    continue
+                existing = self.versions.get(version, {})
+                merged = {**existing, **hashes}
+                if merged != existing:
+                    self.versions[version] = merged
+                    self._dirty = True
+                    for sentinel in hashes:
+                        if sentinel not in self.sentinel_files:
+                            self.sentinel_files.append(sentinel)
 
     def has_version(self, version: str) -> bool:
         return version in self.versions

--- a/src/sims4_updater/core/telemetry.py
+++ b/src/sims4_updater/core/telemetry.py
@@ -7,6 +7,7 @@ and never raise.  The module respects the ``telemetry_enabled`` setting.
 
 from __future__ import annotations
 
+import concurrent.futures
 import contextlib
 import datetime
 import logging
@@ -41,6 +42,7 @@ class TelemetryClient:
         self._game_info: dict[str, Any] = {}
         self._heartbeat_stop: threading.Event | None = None
         self._disabled = False  # set True on 403 to stop further requests
+        self._pool = concurrent.futures.ThreadPoolExecutor(max_workers=2)
         self._ensure_uid()
 
     # ── UID management ────────────────────────────────────────
@@ -61,7 +63,7 @@ class TelemetryClient:
 
     def set_base_url(self, url: str) -> None:
         """Update the telemetry endpoint URL (e.g. from CDN manifest config)."""
-        if url:
+        if url and url.startswith("https://"):
             self._base_url = url
 
     # ── Game info cache ───────────────────────────────────────
@@ -186,7 +188,8 @@ class TelemetryClient:
 
     def _post(self, endpoint: str, data: dict) -> None:
         """POST to the stats API in a background thread. Never blocks the caller."""
-        threading.Thread(target=self._do_post, args=(endpoint, data), daemon=True).start()
+        with contextlib.suppress(RuntimeError):
+            self._pool.submit(self._do_post, endpoint, data)
 
     def _do_post(self, endpoint: str, data: dict) -> None:
         """Actual HTTP POST. Runs on a daemon thread — never raises."""

--- a/src/sims4_updater/core/version_detect.py
+++ b/src/sims4_updater/core/version_detect.py
@@ -113,7 +113,7 @@ class VersionDatabase:
 
         matched_versions = [v for v, _ in matches]
 
-        if len(matches) == 1:
+        if len(matches) == 1 and best_count >= 2:
             confidence = Confidence.DEFINITIVE
         elif best_count >= 2:
             confidence = Confidence.PROBABLE

--- a/src/sims4_updater/dlc/downloader.py
+++ b/src/sims4_updater/dlc/downloader.py
@@ -52,6 +52,8 @@ class DLCDownloadTask:
     progress_bytes: int = 0
     total_bytes: int = 0
     error: str = ""
+    retry_count: int = 0
+    resumed: bool = False
 
 
 # Callback: (dlc_id, state, progress_bytes, total_bytes, message)
@@ -163,6 +165,8 @@ class DLCDownloader:
                         file_entry,
                         progress=dl_progress,
                     )
+                    task.resumed = result.resumed
+                    task.retry_count = attempt
                     break
                 except DownloadError as e:
                     last_exc = e

--- a/src/sims4_updater/dlc/downloader.py
+++ b/src/sims4_updater/dlc/downloader.py
@@ -96,7 +96,9 @@ class DLCDownloader:
     def _wait_if_paused(self) -> None:
         """Block until proceed event is set (unpaused). No-op if no event."""
         if self._proceed is not None:
-            self._proceed.wait()
+            while not self._proceed.wait(timeout=5):
+                if self._cancel.is_set():
+                    return
 
     # ── Single DLC ──────────────────────────────────────────────
 

--- a/src/sims4_updater/dlc/manager.py
+++ b/src/sims4_updater/dlc/manager.py
@@ -142,7 +142,7 @@ class DLCManager:
         # Copy to Bin_LE variant if it exists (matches AutoIt behavior)
         bin_le_path = config_path.parent.parent / "Bin_LE" / config_path.name
         if bin_le_path.parent.is_dir() and bin_le_path != config_path:
-            shutil.copy2(config_path, bin_le_path)
+            _atomic_write(bin_le_path, content, adapter.get_encoding())
 
     def auto_toggle(self, game_dir: str | Path) -> dict[str, bool]:
         """

--- a/src/sims4_updater/dlc/manager.py
+++ b/src/sims4_updater/dlc/manager.py
@@ -5,7 +5,6 @@ DLC Manager — unified interface for toggling DLCs across all crack config form
 import contextlib
 import logging
 import os
-import shutil
 from pathlib import Path
 
 from ..core.exceptions import NoCrackConfigError
@@ -267,9 +266,9 @@ class DLCManager:
                             # Mirror to Bin_LE if present
                             bin_le = config_path.parent.parent / "Bin_LE" / config_path.name
                             if bin_le.parent.is_dir() and bin_le != config_path:
-                                shutil.copy2(config_path, bin_le)
-            except Exception:
-                pass  # Best-effort disable
+                                _atomic_write(bin_le, content, adapter.get_encoding())
+            except Exception as e:
+                logger.warning("Could not disable DLC %s in crack config: %s", dlc_id, e)
 
         return files_removed, files_failed
 

--- a/src/sims4_updater/greenluma/applist.py
+++ b/src/sims4_updater/greenluma/applist.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
 import shutil
 from dataclasses import dataclass
 from datetime import datetime
@@ -133,7 +135,14 @@ def write_applist(applist_dir: Path, app_ids: list[str]) -> int:
     new_files = set()
     for idx, app_id in enumerate(unique):
         target = applist_dir / f"{idx}.txt"
-        target.write_text(app_id, encoding="utf-8")
+        tmp = target.with_suffix(".txt_tmp")
+        try:
+            tmp.write_text(app_id, encoding="utf-8")
+            os.replace(tmp, target)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                tmp.unlink(missing_ok=True)
+            raise
         new_files.add(target.name)
 
     # Remove old numbered .txt files that are no longer needed

--- a/src/sims4_updater/greenluma/contribute.py
+++ b/src/sims4_updater/greenluma/contribute.py
@@ -164,6 +164,8 @@ def submit_gl_contribution(
     base_url = url or CONTRIBUTE_URL
     if not base_url:
         return {"status": "error", "message": "Contribution URL not configured."}
+    if not base_url.startswith("https://"):
+        return {"status": "error", "message": "Contribution URL must use HTTPS."}
 
     # Replace /contribute with /contribute/greenluma
     if base_url.endswith("/contribute"):

--- a/src/sims4_updater/greenluma/installer.py
+++ b/src/sims4_updater/greenluma/installer.py
@@ -292,9 +292,12 @@ def uninstall_greenluma(steam_path: Path) -> tuple[int, int]:
     manifest = _load_install_manifest()
 
     if manifest:
-        install_dir = Path(manifest["install_dir"])
+        install_dir = Path(manifest["install_dir"]).resolve()
         for rel_path in manifest.get("files", []):
-            fp = install_dir / rel_path
+            fp = (install_dir / rel_path).resolve()
+            if not fp.is_relative_to(install_dir):
+                log.warning("Skipping unsafe uninstall path: %s", rel_path)
+                continue
             if fp.is_file():
                 try:
                     fp.unlink()

--- a/src/sims4_updater/greenluma/installer.py
+++ b/src/sims4_updater/greenluma/installer.py
@@ -43,13 +43,23 @@ def _get_manifest_path() -> Path:
 
 def _save_install_manifest(target_dir: Path, files: list[str]) -> None:
     """Save list of installed file paths relative to target_dir."""
+    import os as _os
+
     path = _get_manifest_path()
     data = {
         "install_dir": str(target_dir),
         "files": files,
         "installed_at": datetime.now().isoformat(),
     }
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json_tmp")
+    try:
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        _os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp.unlink(missing_ok=True)
+        raise
     log.info("Saved install manifest: %d files to %s", len(files), path)
 
 

--- a/src/sims4_updater/greenluma/steam.py
+++ b/src/sims4_updater/greenluma/steam.py
@@ -77,22 +77,23 @@ def _read_steam_path_from_registry() -> Path | None:
     except ImportError:
         return None
 
-    for view in (
-        winreg.KEY_READ | winreg.KEY_WOW64_64KEY,
-        winreg.KEY_READ | winreg.KEY_WOW64_32KEY,
-    ):
-        try:
-            with winreg.OpenKey(
-                winreg.HKEY_LOCAL_MACHINE,
-                _STEAM_REGISTRY_KEY,
-                0,
-                view,
-            ) as key:
-                value, _ = winreg.QueryValueEx(key, _STEAM_REGISTRY_VALUE)
-                if value:
-                    return Path(value)
-        except (OSError, FileNotFoundError):
-            continue
+    for hive in (winreg.HKEY_LOCAL_MACHINE, winreg.HKEY_CURRENT_USER):
+        for view in (
+            winreg.KEY_READ | winreg.KEY_WOW64_64KEY,
+            winreg.KEY_READ | winreg.KEY_WOW64_32KEY,
+        ):
+            try:
+                with winreg.OpenKey(
+                    hive,
+                    _STEAM_REGISTRY_KEY,
+                    0,
+                    view,
+                ) as key:
+                    value, _ = winreg.QueryValueEx(key, _STEAM_REGISTRY_VALUE)
+                    if value:
+                        return Path(value)
+            except (OSError, FileNotFoundError):
+                continue
 
     return None
 

--- a/src/sims4_updater/gui/app.py
+++ b/src/sims4_updater/gui/app.py
@@ -715,7 +715,7 @@ class App(ctk.CTk):
             event.set()
 
         self._enqueue_gui(_show)
-        event.wait()
+        event.wait(timeout=120)
         return result[0] if result else False
 
     def _show_error(self, error: Exception):
@@ -1157,6 +1157,8 @@ class App(ctk.CTk):
         try:
             self._animator.cancel_all()
             self.updater.exiting.set()
+            # Cancel any in-progress downloads so background threads unblock
+            self.updater._cancel.set()
             # Save window geometry before closing
             self.settings.window_geometry = self.geometry()
             self.settings.save()

--- a/src/sims4_updater/gui/frames/diagnostics_frame.py
+++ b/src/sims4_updater/gui/frames/diagnostics_frame.py
@@ -240,13 +240,12 @@ class DiagnosticsFrame(ctk.CTkFrame):
             self.app._enqueue_gui(self._on_validate_error, "No game directory found.")
             return
 
-        self._validator = GameValidator()
-
         def progress(msg, current, total):
             pct = current / total if total > 0 else 0
             self.app._enqueue_gui(self._update_validate_progress, msg, pct)
 
         try:
+            self._validator = GameValidator()
             report = self._validator.validate(
                 game_dir,
                 progress=progress,

--- a/src/sims4_updater/gui/frames/dlc_frame.py
+++ b/src/sims4_updater/gui/frames/dlc_frame.py
@@ -1220,6 +1220,9 @@ class DLCFrame(ctk.CTkFrame):
         self._status_label.configure(text="Applying changes...")
 
         enabled_set = {dlc_id for dlc_id, var in self._checkbox_vars.items() if var.get()}
+        # Snapshot current state for telemetry diff
+        self._pre_apply_enabled = {s.dlc.id for s in self._all_states if s.enabled is True}
+        self._apply_enabled_set = enabled_set
         self.app.run_async(
             self._apply_bg,
             enabled_set,
@@ -1236,10 +1239,18 @@ class DLCFrame(ctk.CTkFrame):
     def _on_apply_done(self, _):
         self._apply_btn.configure(state="normal")
         self.app.show_toast("Changes applied successfully", "success")
+        # Compute toggled DLCs for telemetry
+        prev = getattr(self, "_pre_apply_enabled", set())
+        curr = getattr(self, "_apply_enabled_set", set())
+        newly_enabled = sorted(curr - prev)
+        newly_disabled = sorted(prev - curr)
         self.app.telemetry.track_event(
             "dlc_changes_applied",
             {
-                "dlcs_changed": sum(1 for v in self._checkbox_vars.values() if v.get()),
+                "enabled_count": len(newly_enabled),
+                "disabled_count": len(newly_disabled),
+                "enabled_ids": newly_enabled[:20],
+                "disabled_ids": newly_disabled[:20],
                 "crack_format": getattr(self.app.updater, "_detected_format", None),
             },
         )

--- a/src/sims4_updater/gui/frames/downloader_frame.py
+++ b/src/sims4_updater/gui/frames/downloader_frame.py
@@ -821,8 +821,10 @@ class DownloaderFrame(ctk.CTkFrame):
             "dlc_download_started",
             {
                 "dlc_count": len(entries),
+                "dlc_ids": [e.dlc_id for e in entries],
                 "total_size_bytes": total_download_size,
                 "concurrency": self.app.settings.download_concurrency,
+                "speed_limit_mb": self.app.settings.download_speed_limit or 0,
             },
         )
 
@@ -1026,6 +1028,14 @@ class DownloaderFrame(ctk.CTkFrame):
             size_str = _format_size(entry.size) if entry and entry.size > 0 else ""
             size_part = f" ({size_str})" if size_str else ""
             self._log(f"[{_timestamp()}] Downloading {dlc_id} \u2014 {name}{size_part}...")
+            self.app.telemetry.track_event(
+                "dlc_item_started",
+                {
+                    "dlc_id": dlc_id,
+                    "pack_type": info.pack_type if info else None,
+                    "size_bytes": entry.size if entry else 0,
+                },
+            )
 
         # Update overall progress bar using byte-level progress
         total_size = sum(e.size for e in self._download_entries) if self._download_entries else 0
@@ -1108,8 +1118,12 @@ class DownloaderFrame(ctk.CTkFrame):
             self._log(f"[{_timestamp()}] Average speed: {avg_speed}")
 
         # Per-DLC telemetry events
+        catalog = self.app.updater._dlc_manager.catalog
+        total_retries = 0
         for r in results:
             dlc_id = r.entry.dlc_id
+            cinfo = catalog.get_by_id(dlc_id)
+            pack_type = cinfo.pack_type if cinfo else None
             if r.state in (DLCDownloadState.COMPLETED, DLCDownloadState.EXTRACTED):
                 dlc_dur = duration
                 start = self._dlc_start_times.get(dlc_id)
@@ -1117,26 +1131,35 @@ class DownloaderFrame(ctk.CTkFrame):
                     dlc_dur = time.monotonic() - start
                 dlc_size = self._dlc_bytes.get(dlc_id, r.entry.size)
                 speed = dlc_size / dlc_dur if dlc_dur > 0 else 0
+                total_retries += r.retry_count
                 self.app.telemetry.track_event(
                     "dlc_download_complete",
                     {
                         "dlc_id": dlc_id,
+                        "pack_type": pack_type,
                         "size_bytes": dlc_size,
                         "duration_seconds": round(dlc_dur, 1),
                         "speed_bps": round(speed),
+                        "resumed": r.resumed,
+                        "retries": r.retry_count,
+                        "registered": r.state == DLCDownloadState.COMPLETED,
                     },
                 )
             elif r.state == DLCDownloadState.FAILED:
+                total_retries += r.retry_count
                 self.app.telemetry.track_event(
                     "dlc_download_failed",
                     {
                         "dlc_id": dlc_id,
-                        "error": str(r.error) if r.error else None,
+                        "pack_type": pack_type,
+                        "error": str(r.error)[:200] if r.error else None,
+                        "retries": r.retry_count,
                     },
                 )
 
         # Batch summary event
         avg_speed = total_bytes / duration if duration > 0 else 0
+        dlc_ids = [r.entry.dlc_id for r in results if r.state != DLCDownloadState.CANCELLED]
         self.app.telemetry.track_event(
             "dlc_batch_complete",
             {
@@ -1146,6 +1169,8 @@ class DownloaderFrame(ctk.CTkFrame):
                 "total_bytes": total_bytes,
                 "duration_seconds": round(duration, 1),
                 "avg_speed_bps": round(avg_speed),
+                "total_retries": total_retries,
+                "dlc_ids": dlc_ids,
             },
         )
 
@@ -1182,8 +1207,13 @@ class DownloaderFrame(ctk.CTkFrame):
             dl.pause()
         self._pause_btn.grid_remove()
         self._resume_btn.grid()
+        self._pause_start_time = time.monotonic()
         self._log(f"[{_timestamp()}] Downloads paused")
-        self.app.telemetry.track_event("dlc_download_paused")
+        elapsed = time.monotonic() - self._download_start_time
+        self.app.telemetry.track_event(
+            "dlc_download_paused",
+            {"elapsed_seconds": round(elapsed, 1)},
+        )
 
     def _on_resume(self):
         with self._dl_lock:
@@ -1192,8 +1222,15 @@ class DownloaderFrame(ctk.CTkFrame):
             dl.resume()
         self._resume_btn.grid_remove()
         self._pause_btn.grid()
+        pause_dur = 0.0
+        if hasattr(self, "_pause_start_time") and self._pause_start_time:
+            pause_dur = time.monotonic() - self._pause_start_time
+            self._pause_start_time = 0.0
         self._log(f"[{_timestamp()}] Downloads resumed")
-        self.app.telemetry.track_event("dlc_download_resumed")
+        self.app.telemetry.track_event(
+            "dlc_download_resumed",
+            {"pause_duration_seconds": round(pause_dur, 1)},
+        )
 
     def _on_cancel(self):
         with self._dl_lock:
@@ -1207,10 +1244,13 @@ class DownloaderFrame(ctk.CTkFrame):
         self._resume_btn.grid_remove()
         self._log(f"[{_timestamp()}] Cancellation requested...")
         elapsed = time.monotonic() - self._download_start_time
+        completed_so_far = self._completed_count + self._extracted_count
         self.app.telemetry.track_event(
             "dlc_download_cancelled",
             {
                 "elapsed_seconds": round(elapsed, 1),
+                "completed_before_cancel": completed_so_far,
+                "total_requested": self._total_to_download,
             },
         )
 

--- a/src/sims4_updater/gui/frames/events_frame.py
+++ b/src/sims4_updater/gui/frames/events_frame.py
@@ -267,7 +267,8 @@ class EventsFrame(ctk.CTkFrame):
     # ── Status Refresh ───────────────────────────────────────────
 
     def on_show(self):
-        self._refresh()
+        if not self._busy:
+            self._refresh()
 
     def _on_refresh(self):
         self._refresh()

--- a/src/sims4_updater/gui/frames/greenluma_frame.py
+++ b/src/sims4_updater/gui/frames/greenluma_frame.py
@@ -304,7 +304,8 @@ class GreenLumaFrame(ctk.CTkFrame):
     # ── Lifecycle ────────────────────────────────────────────────
 
     def on_show(self):
-        self._refresh_status()
+        if not self._busy:
+            self._refresh_status()
 
     def _refresh_status(self):
         self._steam_path_badge.set_status("Scanning...", "muted")

--- a/src/sims4_updater/gui/frames/greenluma_frame.py
+++ b/src/sims4_updater/gui/frames/greenluma_frame.py
@@ -585,22 +585,30 @@ class GreenLumaFrame(ctk.CTkFrame):
             self.app.show_toast("GreenLuma not installed or injector not found.", "warning")
             return
 
-        # Check if Steam is running before launching
-        from ...greenluma.steam import is_steam_running
+        # Check if Steam is running (off GUI thread to avoid blocking)
+        injector_path = gl.dll_injector_path
 
-        if is_steam_running():
-            restart = ask_yes_no(
-                self.app,
-                title="Steam is Running",
-                message="Steam must be closed to relaunch with GreenLuma.\n\n"
-                "Would you like to close Steam and relaunch it\n"
-                "with GreenLuma DLC unlocking enabled?",
-            )
-            if not restart:
-                return
-            self._launch_gl_with_kill(gl.dll_injector_path)
-        else:
-            self._launch_gl_direct(gl.dll_injector_path)
+        def _check_bg():
+            from ...greenluma.steam import is_steam_running
+
+            return is_steam_running()
+
+        def _check_done(running):
+            if running:
+                restart = ask_yes_no(
+                    self.app,
+                    title="Steam is Running",
+                    message="Steam must be closed to relaunch with GreenLuma.\n\n"
+                    "Would you like to close Steam and relaunch it\n"
+                    "with GreenLuma DLC unlocking enabled?",
+                )
+                if not restart:
+                    return
+                self._launch_gl_with_kill(injector_path)
+            else:
+                self._launch_gl_direct(injector_path)
+
+        self.app.run_async(_check_bg, on_done=_check_done)
 
     def _launch_gl_with_kill(self, injector_path: Path):
         """Kill Steam then launch via GreenLuma."""
@@ -770,17 +778,26 @@ class GreenLumaFrame(ctk.CTkFrame):
             self.app.show_toast("No CDN keys available yet.", "info")
             return
 
-        # Check Steam is not running
-        from ...greenluma.steam import is_steam_running
-
-        if is_steam_running():
-            self.app.show_toast("Close Steam before applying CDN keys.", "warning")
-            return
-
-        self._set_busy(True)
-        self._log("--- Applying CDN Keys ---")
+        # Check Steam is not running (off GUI thread)
         steam_info = self._steam_info
         gl_entries = manifest.greenluma
+
+        def _check_steam_bg():
+            from ...greenluma.steam import is_steam_running
+
+            return is_steam_running()
+
+        def _check_steam_done(running):
+            if running:
+                self.app.show_toast("Close Steam before applying CDN keys.", "warning")
+                return
+            self._apply_cdn_keys_inner(steam_info, gl_entries)
+
+        self.app.run_async(_check_steam_bg, on_done=_check_steam_done)
+
+    def _apply_cdn_keys_inner(self, steam_info, gl_entries):
+        self._set_busy(True)
+        self._log("--- Applying CDN Keys ---")
 
         def _bg():
             from ...greenluma.orchestrator import GreenLumaOrchestrator

--- a/src/sims4_updater/gui/frames/language_frame.py
+++ b/src/sims4_updater/gui/frames/language_frame.py
@@ -872,8 +872,7 @@ class LanguageFrame(ctk.CTkFrame):
                         "size_bytes": entry.size if hasattr(entry, "size") else None,
                     },
                 )
-                # Now apply the language config
-                self._refresh_status()
+                # Apply the language config (refresh status after apply completes)
                 self._apply_language(code)
             else:
                 self._set_busy(False)

--- a/src/sims4_updater/gui/frames/language_frame.py
+++ b/src/sims4_updater/gui/frames/language_frame.py
@@ -332,7 +332,8 @@ class LanguageFrame(ctk.CTkFrame):
     # ── Status ───────────────────────────────────────────────────
 
     def on_show(self):
-        self._refresh_status()
+        if not self._busy:
+            self._refresh_status()
 
     def _on_version_changed(self, choice: str):
         """Handle version dropdown change — reload language packs from archived manifest."""

--- a/src/sims4_updater/gui/frames/mods_frame.py
+++ b/src/sims4_updater/gui/frames/mods_frame.py
@@ -202,7 +202,8 @@ class ModsFrame(ctk.CTkFrame):
     # ── Status Refresh ────────────────────────────────────────────
 
     def on_show(self):
-        self._refresh()
+        if not self._busy:
+            self._refresh()
 
     def _on_refresh(self):
         self._refresh()

--- a/src/sims4_updater/gui/frames/mods_frame.py
+++ b/src/sims4_updater/gui/frames/mods_frame.py
@@ -618,8 +618,9 @@ class ModsFrame(ctk.CTkFrame):
         mgr = self._get_manager()
 
         def _bg():
-            # Register the detected mod temporarily so enable works
-            mgr._registry[mod.name] = mod
+            # Register the detected mod so enable works (thread-safe via lock)
+            with mgr._registry_lock:
+                mgr._registry[mod.name] = mod
             mgr.save_registry()
             return mgr.enable_mod(mod.name, log=self._enqueue_log)
 
@@ -641,7 +642,8 @@ class ModsFrame(ctk.CTkFrame):
         mgr = self._get_manager()
 
         def _bg():
-            mgr._registry[mod.name] = mod
+            with mgr._registry_lock:
+                mgr._registry[mod.name] = mod
             mgr.save_registry()
             return mgr.disable_mod(mod.name, log=self._enqueue_log)
 
@@ -673,7 +675,8 @@ class ModsFrame(ctk.CTkFrame):
         mgr = self._get_manager()
 
         def _bg():
-            mgr._registry[mod.name] = mod
+            with mgr._registry_lock:
+                mgr._registry[mod.name] = mod
             mgr.save_registry()
             return mgr.uninstall_mod(mod.name, log=self._enqueue_log)
 

--- a/src/sims4_updater/gui/frames/progress_frame.py
+++ b/src/sims4_updater/gui/frames/progress_frame.py
@@ -278,10 +278,25 @@ class ProgressFrame(ctk.CTkFrame):
         updater = self.app.updater
         updater.reset_cancel()
 
-        # Download
+        # Phase 1: Download patches
+        dl_start = time.monotonic()
         updater.download_update(plan)
+        dl_duration = time.monotonic() - dl_start
+        self.app.telemetry.track_event(
+            "patch_download_complete",
+            {
+                "from_version": plan.current_version,
+                "to_version": plan.target_version,
+                "steps": plan.step_count,
+                "total_size_bytes": plan.total_download_size,
+                "duration_seconds": round(dl_duration, 1),
+                "avg_speed_bps": round(plan.total_download_size / dl_duration)
+                if dl_duration > 0
+                else 0,
+            },
+        )
 
-        # Load metadata and patch
+        # Phase 2: Load metadata and apply patches
         game_dir = updater.find_game_dir()
         if game_dir:
             game_names = updater.load_all_metadata()
@@ -347,7 +362,17 @@ class ProgressFrame(ctk.CTkFrame):
                         "warning",
                     )
 
+            apply_start = time.monotonic()
             updater.patch(selected)
+            apply_duration = time.monotonic() - apply_start
+            self.app.telemetry.track_event(
+                "patch_apply_complete",
+                {
+                    "to_version": plan.target_version,
+                    "duration_seconds": round(apply_duration, 1),
+                    "dlc_count": len(selected),
+                },
+            )
 
             # Learn new version hashes
             target_version = plan.target_version
@@ -392,7 +417,10 @@ class ProgressFrame(ctk.CTkFrame):
         self.app.telemetry.track_event(
             "update_completed",
             {
+                "from_version": plan.current_version if plan else None,
                 "to_version": plan.target_version if plan else None,
+                "steps": plan.step_count if plan else None,
+                "total_size_bytes": plan.total_download_size if plan else None,
                 "duration_seconds": duration,
             },
         )

--- a/src/sims4_updater/gui/frames/unlocker_frame.py
+++ b/src/sims4_updater/gui/frames/unlocker_frame.py
@@ -178,7 +178,8 @@ class UnlockerFrame(ctk.CTkFrame):
 
     def on_show(self):
         """Called when frame becomes visible."""
-        self._refresh_status()
+        if not self._busy:
+            self._refresh_status()
 
     def _refresh_status(self):
         """Detect client and update status badges."""

--- a/src/sims4_updater/language/changer.py
+++ b/src/sims4_updater/language/changer.py
@@ -434,6 +434,18 @@ def _update_anadius_configs(
     return updated
 
 
+def _atomic_write_cfg(path: Path, content: str) -> None:
+    """Write a config file atomically via temp file + os.replace."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp.unlink(missing_ok=True)
+        raise
+
+
 def _ensure_language_override(
     override_path: Path,
     language_code: str,
@@ -455,7 +467,7 @@ def _ensure_language_override(
                 content,
             )
             if new_content != content:
-                override_path.write_text(new_content, encoding="utf-8")
+                _atomic_write_cfg(override_path, new_content)
                 log(f"Updated override: {override_path}")
                 log(f'  Language = "{language_code}"')
             else:
@@ -477,7 +489,7 @@ def _ensure_language_override(
             idx = content.rfind("}")
             if idx >= 0:
                 new_content = content[:idx] + game_section + content[idx:]
-                override_path.write_text(new_content, encoding="utf-8")
+                _atomic_write_cfg(override_path, new_content)
                 log(f"Added language section to override: {override_path}")
                 return
 
@@ -486,7 +498,7 @@ def _ensure_language_override(
         languages=_ALL_LANGUAGES_CSV,
         language=language_code,
     )
-    override_path.write_text(content, encoding="utf-8")
+    _atomic_write_cfg(override_path, content)
     log(f"Created override: {override_path}")
 
 

--- a/src/sims4_updater/language/changer.py
+++ b/src/sims4_updater/language/changer.py
@@ -314,7 +314,7 @@ def _set_registry_language(language_code: str) -> bool:
         winreg.KEY_WRITE | winreg.KEY_WOW64_32KEY,
     ):
         try:
-            with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, REGISTRY_KEY, 0, view) as key:
+            with winreg.CreateKeyEx(winreg.HKEY_LOCAL_MACHINE, REGISTRY_KEY, 0, view) as key:
                 winreg.SetValueEx(key, REGISTRY_VALUE, 0, winreg.REG_SZ, language_code)
                 success = True
         except (OSError, PermissionError):
@@ -545,7 +545,9 @@ def _update_steam_manifest(
         )
 
         if content != original:
-            manifest.write_text(content, encoding="utf-8")
+            tmp = manifest.with_suffix(".acf_tmp")
+            tmp.write_text(content, encoding="utf-8")
+            os.replace(tmp, manifest)
             log(f"Steam manifest updated: {manifest}")
             log(f'  language = "{steam_lang}"')
             return True

--- a/src/sims4_updater/language/steam.py
+++ b/src/sims4_updater/language/steam.py
@@ -130,6 +130,10 @@ class SteamLanguageDownloader:
                 log(f"ERROR: Could not find {DEPOT_DOWNLOADER_ASSET} in release.")
                 return False
 
+            if not download_url.startswith("https://"):
+                log("ERROR: Download URL is not HTTPS — aborting for security.")
+                return False
+
             version = release.get("tag_name", "unknown")
             size_mb = asset_size / (1024 * 1024)
             log(f"Downloading DepotDownloader {version} ({size_mb:.1f} MB)...")

--- a/src/sims4_updater/mods/manager.py
+++ b/src/sims4_updater/mods/manager.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import shutil
+import threading
 import zipfile
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
@@ -54,6 +55,7 @@ class ModManager:
         self._game_mods_dir = Path(game_mods_dir)
         self._registry_path = get_app_dir() / "mod_registry.json"
         self._registry: dict[str, ModInfo] = {}
+        self._registry_lock = threading.Lock()
         self.load_registry()
 
     # ── Registry persistence ───────────────────────────────────

--- a/src/sims4_updater/patch/downloader.py
+++ b/src/sims4_updater/patch/downloader.py
@@ -179,7 +179,9 @@ class Downloader:
                 with open(partial_path, mode) as f:
                     for chunk in resp.iter_content(CHUNK_SIZE):
                         if self._proceed is not None:
-                            self._proceed.wait()  # block if paused
+                            while not self._proceed.wait(timeout=5):
+                                if self.cancelled:
+                                    raise DownloadError("Download cancelled.")
                         if self.cancelled:
                             raise DownloadError("Download cancelled.")
                         f.write(chunk)

--- a/src/sims4_updater/patch/downloader.py
+++ b/src/sims4_updater/patch/downloader.py
@@ -69,9 +69,10 @@ class Downloader:
         if self._session is None:
             with self._session_lock:
                 if self._session is None:
-                    self._session = _create_session()
+                    s = _create_session()
                     if self._auth:
-                        self._session.auth = self._auth
+                        s.auth = self._auth
+                    self._session = s  # publish fully configured
         return self._session
 
     def cancel(self):

--- a/supabase/migrations/20260303_download_telemetry_views.sql
+++ b/supabase/migrations/20260303_download_telemetry_views.sql
@@ -1,0 +1,351 @@
+-- Migration: Enhanced download and DLC tracking analytics
+-- Adds views and updates get_stats() for new telemetry events:
+--   dlc_item_started, patch_download_complete, patch_apply_complete,
+--   enriched dlc_download_complete (pack_type, resumed, retries, registered),
+--   enriched dlc_changes_applied (enabled_ids, disabled_ids),
+--   enriched dlc_batch_complete (total_retries, dlc_ids)
+
+-- DLC downloads by pack type (last 30 days)
+CREATE OR REPLACE VIEW public.dlc_downloads_by_pack_type AS
+SELECT
+  coalesce(metadata->>'pack_type', 'unknown') AS pack_type,
+  count(*) AS downloads,
+  coalesce(sum(public.safe_bigint(metadata->>'size_bytes')), 0) AS total_bytes,
+  coalesce(avg(public.safe_float(metadata->>'duration_seconds')), 0) AS avg_duration,
+  coalesce(avg(public.safe_float(metadata->>'speed_bps')), 0) AS avg_speed_bps,
+  sum(CASE WHEN (metadata->>'resumed')::boolean THEN 1 ELSE 0 END) AS resumed_count,
+  coalesce(sum(public.safe_bigint(metadata->>'retries')), 0) AS total_retries
+FROM public.events
+WHERE event_type = 'dlc_download_complete'
+  AND created_at > now() - interval '30 days'
+GROUP BY metadata->>'pack_type'
+ORDER BY downloads DESC;
+
+-- Patch update download performance (last 30 days)
+CREATE OR REPLACE VIEW public.patch_download_stats AS
+SELECT
+  count(*) AS total_downloads,
+  coalesce(sum(public.safe_bigint(metadata->>'total_size_bytes')), 0) AS total_bytes,
+  coalesce(avg(public.safe_float(metadata->>'duration_seconds')), 0) AS avg_download_duration,
+  coalesce(avg(public.safe_float(metadata->>'avg_speed_bps')), 0) AS avg_speed_bps
+FROM public.events
+WHERE event_type = 'patch_download_complete'
+  AND created_at > now() - interval '30 days';
+
+-- Patch apply performance (last 30 days)
+CREATE OR REPLACE VIEW public.patch_apply_stats AS
+SELECT
+  count(*) AS total_applies,
+  coalesce(avg(public.safe_float(metadata->>'duration_seconds')), 0) AS avg_apply_duration
+FROM public.events
+WHERE event_type = 'patch_apply_complete'
+  AND created_at > now() - interval '30 days';
+
+-- DLC toggle summary (last 30 days)
+CREATE OR REPLACE VIEW public.dlc_toggle_stats AS
+SELECT
+  count(*) AS total_applies,
+  coalesce(sum(public.safe_bigint(metadata->>'enabled_count')), 0) AS total_enabled,
+  coalesce(sum(public.safe_bigint(metadata->>'disabled_count')), 0) AS total_disabled
+FROM public.events
+WHERE event_type = 'dlc_changes_applied'
+  AND created_at > now() - interval '30 days';
+
+-- Performance index for pack_type queries
+CREATE INDEX IF NOT EXISTS idx_events_dlc_pack_type
+  ON public.events ((metadata->>'pack_type'))
+  WHERE event_type = 'dlc_download_complete';
+
+-- Performance index for patch download events
+CREATE INDEX IF NOT EXISTS idx_events_patch_download
+  ON public.events (created_at DESC)
+  WHERE event_type = 'patch_download_complete';
+
+-- Update get_stats() RPC to include new analytics sections
+CREATE OR REPLACE FUNCTION public.get_stats(p_days INTEGER DEFAULT 30)
+RETURNS JSONB AS $$
+DECLARE
+  cutoff TIMESTAMPTZ;
+  result JSONB := '{}'::JSONB;
+  tmp JSONB;
+BEGIN
+  IF p_days <= 0 THEN
+    cutoff := '1970-01-01'::TIMESTAMPTZ;
+  ELSE
+    cutoff := now() - (p_days || ' days')::INTERVAL;
+  END IF;
+
+  -- online_users (always last 6 min, not affected by range)
+  SELECT jsonb_build_object('count', count(*))
+  INTO tmp
+  FROM public.users WHERE last_seen > now() - interval '6 minutes';
+  result := result || jsonb_build_object('online_users', jsonb_build_array(tmp));
+
+  -- active_users
+  SELECT jsonb_build_object(
+    'dau', count(*) FILTER (WHERE last_seen > now() - interval '1 day'),
+    'wau', count(*) FILTER (WHERE last_seen > now() - interval '7 days'),
+    'mau', count(*) FILTER (WHERE last_seen > now() - interval '30 days'),
+    'total', count(*)
+  )
+  INTO tmp
+  FROM public.users;
+  result := result || jsonb_build_object('active_users', jsonb_build_array(tmp));
+
+  -- version_stats
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT app_version, count(*) AS count FROM public.users
+    WHERE last_seen > cutoff
+    GROUP BY app_version ORDER BY count DESC
+  ) t;
+  result := result || jsonb_build_object('version_stats', tmp);
+
+  -- game_version_stats
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT coalesce(game_version, 'unknown') AS game_version, count(*) AS count
+    FROM public.users WHERE last_seen > cutoff AND game_detected = TRUE
+    GROUP BY game_version ORDER BY count DESC
+  ) t;
+  result := result || jsonb_build_object('game_version_stats', tmp);
+
+  -- crack_format_stats
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT coalesce(crack_format, 'unknown') AS crack_format, count(*) AS count
+    FROM public.users WHERE last_seen > cutoff
+    GROUP BY crack_format ORDER BY count DESC
+  ) t;
+  result := result || jsonb_build_object('crack_format_stats', tmp);
+
+  -- locale_stats
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT coalesce(locale, 'unknown') AS locale, count(*) AS count
+    FROM public.users WHERE last_seen > cutoff
+    GROUP BY locale ORDER BY count DESC
+  ) t;
+  result := result || jsonb_build_object('locale_stats', tmp);
+
+  -- event_stats
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT event_type, count(*) AS count FROM public.events
+    WHERE created_at > cutoff
+    GROUP BY event_type ORDER BY count DESC
+  ) t;
+  result := result || jsonb_build_object('event_stats', tmp);
+
+  -- popular_dlcs
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT metadata->>'dlc_id' AS dlc_id, count(*) AS downloads,
+      coalesce(sum(public.safe_bigint(metadata->>'size_bytes')), 0) AS total_bytes
+    FROM public.events
+    WHERE event_type = 'dlc_download_complete' AND created_at > cutoff
+    GROUP BY metadata->>'dlc_id' ORDER BY downloads DESC LIMIT 20
+  ) t;
+  result := result || jsonb_build_object('popular_dlcs', tmp);
+
+  -- update_stats
+  SELECT jsonb_build_object(
+    'started', count(*) FILTER (WHERE event_type = 'update_started'),
+    'completed', count(*) FILTER (WHERE event_type = 'update_completed'),
+    'failed', count(*) FILTER (WHERE event_type = 'update_failed')
+  )
+  INTO tmp
+  FROM public.events
+  WHERE event_type IN ('update_started', 'update_completed', 'update_failed')
+    AND created_at > cutoff;
+  result := result || jsonb_build_object('update_stats', jsonb_build_array(tmp));
+
+  -- download_volume
+  SELECT jsonb_build_object(
+    'total_downloads', count(*),
+    'total_bytes', coalesce(sum(public.safe_bigint(metadata->>'size_bytes')), 0),
+    'avg_duration', coalesce(avg(public.safe_float(metadata->>'duration_seconds')), 0),
+    'avg_speed_bps', coalesce(avg(public.safe_float(metadata->>'speed_bps')), 0)
+  )
+  INTO tmp
+  FROM public.events
+  WHERE event_type = 'dlc_download_complete' AND created_at > cutoff;
+  result := result || jsonb_build_object('download_volume', jsonb_build_array(tmp));
+
+  -- session_stats
+  SELECT jsonb_build_object(
+    'total_sessions', count(*),
+    'avg_duration', coalesce(avg(public.safe_float(metadata->>'duration_seconds')), 0),
+    'max_duration', coalesce(max(public.safe_float(metadata->>'duration_seconds')), 0)
+  )
+  INTO tmp
+  FROM public.events
+  WHERE event_type = 'session_end' AND created_at > cutoff;
+  result := result || jsonb_build_object('session_stats', jsonb_build_array(tmp));
+
+  -- feature_usage
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT metadata->>'to_frame' AS feature, count(*) AS visits
+    FROM public.events
+    WHERE event_type = 'frame_navigation' AND created_at > cutoff
+    GROUP BY metadata->>'to_frame' ORDER BY visits DESC
+  ) t;
+  result := result || jsonb_build_object('feature_usage', tmp);
+
+  -- error_summary
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT event_type, count(*) AS count, count(DISTINCT uid) AS affected_users
+    FROM public.events
+    WHERE event_type IN ('update_failed', 'dlc_download_failed', 'update_cancelled', 'dlc_download_cancelled')
+      AND created_at > cutoff
+    GROUP BY event_type ORDER BY count DESC
+  ) t;
+  result := result || jsonb_build_object('error_summary', tmp);
+
+  -- dlc_count_distribution
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB ORDER BY t.sort_order), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT
+      CASE
+        WHEN dlc_count IS NULL THEN 'unknown'
+        WHEN dlc_count = 0 THEN '0'
+        WHEN dlc_count BETWEEN 1 AND 10 THEN '1-10'
+        WHEN dlc_count BETWEEN 11 AND 30 THEN '11-30'
+        WHEN dlc_count BETWEEN 31 AND 60 THEN '31-60'
+        WHEN dlc_count BETWEEN 61 AND 90 THEN '61-90'
+        WHEN dlc_count > 90 THEN '90+'
+      END AS bucket,
+      CASE
+        WHEN dlc_count IS NULL THEN 7
+        WHEN dlc_count = 0 THEN 1
+        WHEN dlc_count BETWEEN 1 AND 10 THEN 2
+        WHEN dlc_count BETWEEN 11 AND 30 THEN 3
+        WHEN dlc_count BETWEEN 31 AND 60 THEN 4
+        WHEN dlc_count BETWEEN 61 AND 90 THEN 5
+        WHEN dlc_count > 90 THEN 6
+      END AS sort_order,
+      count(*) AS count
+    FROM public.users
+    WHERE last_seen > cutoff
+    GROUP BY 1, 2
+  ) t;
+  result := result || jsonb_build_object('dlc_count_distribution', tmp);
+
+  -- daily_active_trend (last N days as time series)
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT d::date AS day, count(DISTINCT e.uid) AS active_users
+    FROM generate_series(
+      GREATEST(cutoff::date, (now() - interval '90 days')::date),
+      now()::date, '1 day'::interval
+    ) AS d
+    LEFT JOIN public.events e
+      ON e.created_at::date = d::date
+      AND e.created_at >= GREATEST(cutoff, now() - interval '90 days')
+    GROUP BY d::date ORDER BY d::date
+  ) t;
+  result := result || jsonb_build_object('daily_active_trend', tmp);
+
+  -- new_users_daily
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT created_at::date AS day, count(*) AS new_users
+    FROM public.users WHERE created_at > cutoff
+    GROUP BY created_at::date ORDER BY created_at::date
+  ) t;
+  result := result || jsonb_build_object('new_users_daily', tmp);
+
+  -- daily_events_trend
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT d::date AS day, count(e.id) AS event_count
+    FROM generate_series(
+      GREATEST(cutoff::date, (now() - interval '90 days')::date),
+      now()::date, '1 day'::interval
+    ) AS d
+    LEFT JOIN public.events e
+      ON e.created_at::date = d::date
+      AND e.created_at >= GREATEST(cutoff, now() - interval '90 days')
+    GROUP BY d::date ORDER BY d::date
+  ) t;
+  result := result || jsonb_build_object('daily_events_trend', tmp);
+
+  -- NEW: dlc_downloads_by_pack_type
+  SELECT coalesce(jsonb_agg(row_to_json(t)::JSONB), '[]'::JSONB)
+  INTO tmp
+  FROM (
+    SELECT
+      coalesce(metadata->>'pack_type', 'unknown') AS pack_type,
+      count(*) AS downloads,
+      coalesce(sum(public.safe_bigint(metadata->>'size_bytes')), 0) AS total_bytes,
+      round(coalesce(avg(public.safe_float(metadata->>'speed_bps')), 0)) AS avg_speed_bps,
+      sum(CASE WHEN (metadata->>'resumed')::text = 'true' THEN 1 ELSE 0 END) AS resumed_count,
+      coalesce(sum(public.safe_bigint(metadata->>'retries')), 0) AS total_retries
+    FROM public.events
+    WHERE event_type = 'dlc_download_complete' AND created_at > cutoff
+    GROUP BY metadata->>'pack_type' ORDER BY downloads DESC
+  ) t;
+  result := result || jsonb_build_object('dlc_by_pack_type', tmp);
+
+  -- NEW: patch_download_performance
+  SELECT jsonb_build_object(
+    'total_downloads', count(*),
+    'total_bytes', coalesce(sum(public.safe_bigint(metadata->>'total_size_bytes')), 0),
+    'avg_download_seconds', round(coalesce(avg(public.safe_float(metadata->>'duration_seconds')), 0)::numeric, 1),
+    'avg_speed_bps', round(coalesce(avg(public.safe_float(metadata->>'avg_speed_bps')), 0))
+  )
+  INTO tmp
+  FROM public.events
+  WHERE event_type = 'patch_download_complete' AND created_at > cutoff;
+  result := result || jsonb_build_object('patch_download_stats', jsonb_build_array(tmp));
+
+  -- NEW: patch_apply_performance
+  SELECT jsonb_build_object(
+    'total_applies', count(*),
+    'avg_apply_seconds', round(coalesce(avg(public.safe_float(metadata->>'duration_seconds')), 0)::numeric, 1)
+  )
+  INTO tmp
+  FROM public.events
+  WHERE event_type = 'patch_apply_complete' AND created_at > cutoff;
+  result := result || jsonb_build_object('patch_apply_stats', jsonb_build_array(tmp));
+
+  -- NEW: dlc_toggle_summary
+  SELECT jsonb_build_object(
+    'total_applies', count(*),
+    'total_enabled', coalesce(sum(public.safe_bigint(metadata->>'enabled_count')), 0),
+    'total_disabled', coalesce(sum(public.safe_bigint(metadata->>'disabled_count')), 0)
+  )
+  INTO tmp
+  FROM public.events
+  WHERE event_type = 'dlc_changes_applied' AND created_at > cutoff;
+  result := result || jsonb_build_object('dlc_toggle_stats', jsonb_build_array(tmp));
+
+  -- NEW: download_reliability (retry and resume rates)
+  SELECT jsonb_build_object(
+    'total_downloads', count(*),
+    'with_retries', count(*) FILTER (WHERE public.safe_bigint(metadata->>'retries') > 0),
+    'with_resume', count(*) FILTER (WHERE (metadata->>'resumed')::text = 'true'),
+    'registration_failures', count(*) FILTER (WHERE (metadata->>'registered')::text = 'false')
+  )
+  INTO tmp
+  FROM public.events
+  WHERE event_type = 'dlc_download_complete' AND created_at > cutoff;
+  result := result || jsonb_build_object('download_reliability', jsonb_build_array(tmp));
+
+  RETURN result;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/tests/test_cdn_auth.py
+++ b/tests/test_cdn_auth.py
@@ -107,27 +107,29 @@ class TestCDNAuth:
 
         assert exc_info.value.cdn_name == "Private CDN"
 
-    def test_network_error_returns_empty_token(self, auth):
-        """Network errors should log a warning, not raise."""
+    def test_network_error_raises(self, auth):
+        """Network errors should raise RuntimeError after failed refresh."""
         import requests
 
-        with patch(
-            "sims4_updater.core.cdn_auth.requests.post",
-            side_effect=requests.ConnectionError("offline"),
+        with (
+            patch(
+                "sims4_updater.core.cdn_auth.requests.post",
+                side_effect=requests.ConnectionError("offline"),
+            ),
+            pytest.raises(RuntimeError, match="Token refresh failed"),
         ):
-            token = auth.get_token()
+            auth.get_token()
 
-        assert token == ""
-
-    def test_non_200_returns_empty_token(self, auth):
-        """Non-200/403 response should log and return empty."""
+    def test_non_200_raises(self, auth):
+        """Non-200/403 response should raise RuntimeError."""
         mock_resp = MagicMock()
         mock_resp.status_code = 500
 
-        with patch("sims4_updater.core.cdn_auth.requests.post", return_value=mock_resp):
-            token = auth.get_token()
-
-        assert token == ""
+        with (
+            patch("sims4_updater.core.cdn_auth.requests.post", return_value=mock_resp),
+            pytest.raises(RuntimeError, match="Token refresh failed"),
+        ):
+            auth.get_token()
 
 
 class TestCDNTokenAuth:
@@ -166,9 +168,9 @@ class TestCDNTokenAuth:
         with patch("sims4_updater.core.cdn_auth.requests.post", return_value=mock_resp):
             adapter = auth.get_auth_adapter()
 
-        mock_request = MagicMock()
-        mock_request.headers = {}
-        result = adapter(mock_request)
+            mock_request = MagicMock()
+            mock_request.headers = {}
+            result = adapter(mock_request)
 
         assert "Authorization" not in result.headers
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -69,6 +69,7 @@ class TestHeartbeat:
         client = TelemetryClient(s)
 
         client.heartbeat(game_version="1.121.372", game_detected=True, dlc_count=5)
+        time.sleep(0.05)  # let pool worker execute
 
         mock_post.assert_called_once()
         url = mock_post.call_args.args[0]
@@ -300,6 +301,7 @@ class TestSessionEnd:
         client.start_periodic_heartbeat(interval=0.05)
         time.sleep(0.1)
         client.session_end()
+        time.sleep(0.1)  # let pool workers drain
         count_after = mock_post.call_count
         time.sleep(0.15)
         assert mock_post.call_count == count_after

--- a/tests/test_version_detect.py
+++ b/tests/test_version_detect.py
@@ -38,10 +38,10 @@ class TestVersionDatabase:
 
     def test_lookup_partial_match(self, version_db_file, tmp_path):
         db = VersionDatabase(db_path=version_db_file, learned_db=_empty_learned(tmp_path))
-        # Only one sentinel matches
+        # Only one sentinel matches — not enough for DEFINITIVE
         result = db.lookup({"Game/Bin/TS4_x64.exe": "ccc333"})
         assert result.version == "1.101.0.1000"
-        assert result.confidence == Confidence.DEFINITIVE
+        assert result.confidence == Confidence.UNKNOWN
 
     def test_lookup_no_match(self, version_db_file, tmp_path):
         db = VersionDatabase(db_path=version_db_file, learned_db=_empty_learned(tmp_path))


### PR DESCRIPTION
## Summary

- **Telemetry v2**: DLC download lifecycle tracking (started/complete/failed/paused/resumed), patch phase tracking with timing metadata, DLC toggle tracking with enabled/disabled IDs
- **Admin dashboard**: 4 new analytics sections (download reliability, patch performance, DLC by pack type, DLC toggles), sparkline charts, time range filters
- **GUI modernization**: themed dialogs, tooltips, RichTextbox, centralized colors, nav animations, lazy frame creation, debounced DLC search
- **Security hardening**: CDN/API worker SSRF protection, HTTPS enforcement, atomic file writes, thread safety fixes, path traversal guards
- **Bug fixes**: 100+ bugs fixed across shutdown hangs, thread safety, data integrity, UI state, crashes
- **Event Rewards Unlocker**: new feature for claiming live-event rewards via GitHub Pages
- **GreenLuma**: improved Steam detection, AppList management, depot key handling
- **New DLC**: Wonderland Playroom and Yard Charm kits added to catalog
- **Supabase**: 8 new migrations (analytics views, stats RPC, performance indexes, download telemetry views)
- **Documentation**: all 5 technical docs + README updated for v2.10.0
- **CHANGELOG.md**: added with full release history
- **CI**: CustomTkinter fork in workflows, ruff version pin update, dependency floor bumps

## Test plan

- [x] `ruff check src/` passes
- [x] `ruff format --check src/` passes
- [ ] `pytest tests/ -v` passes (280 tests)
- [ ] CI checks pass (lint, test, audit, CodeQL)
- [ ] Tag v2.10.0 after merge triggers release workflow